### PR TITLE
fix context of `createUserWithEmail`

### DIFF
--- a/src/components/registerpanel.js
+++ b/src/components/registerpanel.js
@@ -33,7 +33,7 @@ class Registerpanel extends Component {
 		  	<div className={styles.registerpanel}>
 		  		<p>Sign up with email</p>		  		
 
-		  		<form className="newUserform" onSubmit={this.createUserWithEmail}>
+		  		<form className="newUserform" onSubmit={this.createUserWithEmail.bind(this)}>
 					<input ref='email' type='text' placeholder='email' />
 			  		<input ref='password' type='text' placeholder='password' />
 


### PR DESCRIPTION
if I'm not mistaken, the component methods aren't autobound to the component when we use the ES6 class syntax for defining it. Thus we must bind the methods to the component when we use them as callbacks.
